### PR TITLE
[Trusted Types] Legacy converting violations sourced from setHtml wrapper function

### DIFF
--- a/core/creators/themedui.js
+++ b/core/creators/themedui.js
@@ -490,7 +490,7 @@ CKEDITOR.replaceClass = 'ckeditor';
 				'</{outerEl}>' +
 			'</{outerEl}>' );
 
-		var container = CKEDITOR.dom.element.createFromHtml( themedTpl.output( {
+		var container = CKEDITOR.dom.element.createFromHtml( CKEDITOR.tools.legacyUnsafeHtml(themedTpl.output( {
 			id: editor.id,
 			name: name,
 			langDir: editor.lang.dir,
@@ -500,7 +500,7 @@ CKEDITOR.replaceClass = 'ckeditor';
 			contentId: editor.ui.spaceId( 'contents' ),
 			bottomHtml: bottomHtml ? '<span id="' + editor.ui.spaceId( 'bottom' ) + '" class="cke_bottom cke_reset_all" role="presentation">' + bottomHtml + '</span>' : '',
 			outerEl: CKEDITOR.env.ie ? 'span' : 'div'	// https://dev.ckeditor.com/ticket/9571
-		} ) );
+		} ) ) );
 
 		if ( elementMode == CKEDITOR.ELEMENT_MODE_REPLACE ) {
 			element.hide();

--- a/core/editable.js
+++ b/core/editable.js
@@ -504,7 +504,7 @@
 				if ( !isSnapshot )
 					data = this.editor.dataProcessor.toHtml( data );
 
-				this.setHtml( CKEDITOR.tools.htmlLegacyConverted(data) );
+				this.setHtml( CKEDITOR.tools.legacyUnsafeHtml(data) );
 				this.fixInitialSelection();
 
 				// Editable is ready after first setData.

--- a/core/editable.js
+++ b/core/editable.js
@@ -504,7 +504,7 @@
 				if ( !isSnapshot )
 					data = this.editor.dataProcessor.toHtml( data );
 
-				this.setHtml( data );
+				this.setHtml( CKEDITOR.tools.htmlLegacyConverted(data) );
 				this.fixInitialSelection();
 
 				// Editable is ready after first setData.

--- a/core/htmldataprocessor.js
+++ b/core/htmldataprocessor.js
@@ -107,7 +107,7 @@
 			// structure.
 			var el = editor.document.createElement( fixBin );
 			// Add fake character to workaround IE comments bug. (https://dev.ckeditor.com/ticket/3801)
-			el.setHtml( CKEDITOR.tools.htmlLegacyConverted('a' + data) );
+			el.setHtml( CKEDITOR.tools.legacyUnsafeHtml('a' + data) );
 			data = el.getHtml().substr( 1 );
 
 			// Restore shortly protected attribute names.

--- a/core/htmldataprocessor.js
+++ b/core/htmldataprocessor.js
@@ -107,7 +107,7 @@
 			// structure.
 			var el = editor.document.createElement( fixBin );
 			// Add fake character to workaround IE comments bug. (https://dev.ckeditor.com/ticket/3801)
-			el.setHtml( 'a' + data );
+			el.setHtml( CKEDITOR.tools.htmlLegacyConverted('a' + data) );
 			data = el.getHtml().substr( 1 );
 
 			// Restore shortly protected attribute names.

--- a/core/template.js
+++ b/core/template.js
@@ -64,6 +64,6 @@
 				return data[ dataKey ] !== undefined ? data[ dataKey ] : fullMatch;
 			} );
 
-		return CKEDITOR.tools.htmlLegacyConverted(buffer ? buffer.push( output ) : output);
+		return CKEDITOR.tools.legacyUnsafeHtml(buffer ? buffer.push( output ) : output);
 	};
 } )();

--- a/core/template.js
+++ b/core/template.js
@@ -64,6 +64,6 @@
 				return data[ dataKey ] !== undefined ? data[ dataKey ] : fullMatch;
 			} );
 
-		return buffer ? buffer.push( output ) : output;
+		return CKEDITOR.tools.htmlLegacyConverted(buffer ? buffer.push( output ) : output);
 	};
 } )();

--- a/core/template.js
+++ b/core/template.js
@@ -64,6 +64,6 @@
 				return data[ dataKey ] !== undefined ? data[ dataKey ] : fullMatch;
 			} );
 
-		return CKEDITOR.tools.legacyUnsafeHtml(buffer ? buffer.push( output ) : output);
+		return buffer ? buffer.push( output ) : output;
 	};
 } )();

--- a/core/tools.js
+++ b/core/tools.js
@@ -123,6 +123,24 @@
 	 * @singleton
 	 */
 	CKEDITOR.tools = {
+
+		htmlLegacyConverted: function (html) {
+			if (self.trustedTypes && self.trustedTypes.createPolicy) {
+				const policy = self.trustedTypes.createPolicy(
+					'tools#htmlLegacyConverted',
+					{
+						createHTML: function (html) {
+							// This policy is only to be used for legacy conversions.
+							return html;
+						},
+					}
+				);
+				return policy.createHTML(html);
+			} else {
+				return html;
+			}
+		},
+
 		/**
 		 * Compares the elements of two arrays.
 		 *

--- a/core/tools.js
+++ b/core/tools.js
@@ -124,10 +124,21 @@
 	 */
 	CKEDITOR.tools = {
 
-		htmlLegacyConverted: function (html) {
+		/**
+		 * Wraps a possibly unsafe html string in a trusted type. Note that 
+		 * this function does not sanitize or make any changes to the html.
+		 * 
+		 * This function would be used for legacy conversions of inputs to a
+		 * DOM XSS sink that are possibly unsafe but not clear.
+		 *
+		 * @param {string} html The string to be wrapped with a trusted type.
+		 * @returns {TrustedHTML | string} the same html string but as a
+		 * TrustedHTML, or a string if TT is not supported.
+		 */
+		legacyUnsafeHtml: function (html) {
 			if (self.trustedTypes && self.trustedTypes.createPolicy) {
 				const policy = self.trustedTypes.createPolicy(
-					'tools#htmlLegacyConverted',
+					'tools#legacyUnsafeHtml',
 					{
 						createHTML: function (html) {
 							// This policy is only to be used for legacy conversions.

--- a/dev/console/console.js
+++ b/dev/console/console.js
@@ -114,7 +114,7 @@ var CKCONSOLE = ( function() {
 
 	function fromHtml( html, data ) {
 		if ( html instanceof CKEDITOR.template )
-			html = html.output( data );
+			html = CKEDITOR.tools.legacyUnsafeHtml(html.output( data ));
 
 		return CKEDITOR.dom.element.createFromHtml( html );
 	}

--- a/plugins/adobeair/plugin.js
+++ b/plugins/adobeair/plugin.js
@@ -125,14 +125,14 @@
 							// Do that before getDocumentHead because WebKit moves
 							// <link css> elements to the <head> at this point.
 							var div = new CKEDITOR.dom.element( 'div', doc );
-							div.setHtml( CKEDITOR.tools.htmlLegacyConverted(headHtml) );
+							div.setHtml( CKEDITOR.tools.legacyUnsafeHtml(headHtml) );
 							// Move the <div> nodes to <head>.
 							div.moveChildren( head );
 							return '';
 						} );
 
 						html.replace( /(<body[^>]*>)([\s\S]*)(?=$|<\/body>)/i, function( match, startTag, innerHTML ) {
-							doc.getBody().setHtml( CKEDITOR.tools.htmlLegacyConverted(innerHTML) );
+							doc.getBody().setHtml( CKEDITOR.tools.legacyUnsafeHtml(innerHTML) );
 							var attrs = CKEDITOR.htmlParser.fragment.fromHtml( startTag ).children[ 0 ].attributes;
 							attrs && doc.getBody().setAttributes( attrs );
 						} );

--- a/plugins/adobeair/plugin.js
+++ b/plugins/adobeair/plugin.js
@@ -125,14 +125,14 @@
 							// Do that before getDocumentHead because WebKit moves
 							// <link css> elements to the <head> at this point.
 							var div = new CKEDITOR.dom.element( 'div', doc );
-							div.setHtml( headHtml );
+							div.setHtml( CKEDITOR.tools.htmlLegacyConverted(headHtml) );
 							// Move the <div> nodes to <head>.
 							div.moveChildren( head );
 							return '';
 						} );
 
 						html.replace( /(<body[^>]*>)([\s\S]*)(?=$|<\/body>)/i, function( match, startTag, innerHTML ) {
-							doc.getBody().setHtml( innerHTML );
+							doc.getBody().setHtml( CKEDITOR.tools.htmlLegacyConverted(innerHTML) );
 							var attrs = CKEDITOR.htmlParser.fragment.fromHtml( startTag ).children[ 0 ].attributes;
 							attrs && doc.getBody().setAttributes( attrs );
 						} );

--- a/plugins/autocomplete/plugin.js
+++ b/plugins/autocomplete/plugin.js
@@ -845,7 +845,7 @@
 		 */
 		createItem: function( item ) {
 			var encodedItem = encodeItem( item ),
-				itemElement = CKEDITOR.dom.element.createFromHtml( this.itemTemplate.output( encodedItem ), this.document ),
+				itemElement = CKEDITOR.dom.element.createFromHtml( CKEDITOR.tools.legacyUnsafeHtml(this.itemTemplate.output( encodedItem) ), this.document ),
 				id = CKEDITOR.tools.getNextId();
 
 			// Add attributes needed for a11y support (#4617).

--- a/plugins/autoembed/plugin.js
+++ b/plugins/autoembed/plugin.js
@@ -63,7 +63,7 @@
 
 			// TODO Move this to a method in the widget plugin. https://dev.ckeditor.com/ticket/13408
 		var defaults = typeof widgetDef.defaults == 'function' ? widgetDef.defaults() : widgetDef.defaults,
-			element = CKEDITOR.dom.element.createFromHtml( widgetDef.template.output( defaults ) ),
+			element = CKEDITOR.dom.element.createFromHtml( CKEDITOR.tools.legacyUnsafeHtml(widgetDef.template.output( defaults )) ),
 			instance,
 			wrapper = editor.widgets.wrapElement( element, widgetDef.name ),
 			temp = new CKEDITOR.dom.documentFragment( wrapper.getDocument() );

--- a/plugins/balloonpanel/plugin.js
+++ b/plugins/balloonpanel/plugin.js
@@ -201,28 +201,28 @@
 			var editor = this.editor;
 
 			this.parts = {
-				title: CKEDITOR.dom.element.createFromHtml( this.templates.title.output( {
+				title: CKEDITOR.dom.element.createFromHtml( CKEDITOR.tools.legacyUnsafeHtml(this.templates.title.output( {
 					title: this.title
-				} ) ),
+				} ) ) ),
 
-				close: CKEDITOR.dom.element.createFromHtml( this.templates.close.output() ),
+				close: CKEDITOR.dom.element.createFromHtml( CKEDITOR.tools.legacyUnsafeHtml(this.templates.close.output()) ),
 
-				panel: CKEDITOR.dom.element.createFromHtml( this.templates.panel.output( {
+				panel: CKEDITOR.dom.element.createFromHtml( CKEDITOR.tools.legacyUnsafeHtml(this.templates.panel.output( {
 					id: editor.id,
 					langDir: editor.lang.dir,
 					langCode: editor.langCode,
 					name: editor.name,
 					style: 'display:none;',
 					voiceLabel: editor.lang.editorPanel + ', ' + editor.name
-				} ) ),
+				} )) ),
 
-				content: CKEDITOR.dom.element.createFromHtml( this.templates.content.output( {
+				content: CKEDITOR.dom.element.createFromHtml( CKEDITOR.tools.legacyUnsafeHtml(this.templates.content.output( {
 					content: this.content || ''
-				} ) ),
+				} )) ),
 
-				triangleOuter: CKEDITOR.dom.element.createFromHtml( this.templates.triangleOuter.output() ),
+				triangleOuter: CKEDITOR.dom.element.createFromHtml( CKEDITOR.tools.legacyUnsafeHtml(this.templates.triangleOuter.output()) ),
 
-				triangleInner: CKEDITOR.dom.element.createFromHtml( this.templates.triangleInner.output() )
+				triangleInner: CKEDITOR.dom.element.createFromHtml( CKEDITOR.tools.legacyUnsafeHtml(this.templates.triangleInner.output()) )
 			};
 
 			// Append UI elements to create a panel.

--- a/plugins/devtools/plugin.js
+++ b/plugins/devtools/plugin.js
@@ -32,7 +32,7 @@ CKEDITOR.plugins.add( 'devtools', {
 
 		str += '<li><strong>' + lang.elementType + '</strong> : ' + link + '</li>';
 
-		return CKEDITOR.tools.htmlLegacyConverted(str + '</ul>');
+		return CKEDITOR.tools.legacyUnsafeHtml(str + '</ul>');
 	}
 
 	function showTooltip( callback, el, editor, dialog, obj, tabName ) {

--- a/plugins/devtools/plugin.js
+++ b/plugins/devtools/plugin.js
@@ -32,7 +32,7 @@ CKEDITOR.plugins.add( 'devtools', {
 
 		str += '<li><strong>' + lang.elementType + '</strong> : ' + link + '</li>';
 
-		return str + '</ul>';
+		return CKEDITOR.tools.htmlLegacyConverted(str + '</ul>');
 	}
 
 	function showTooltip( callback, el, editor, dialog, obj, tabName ) {

--- a/plugins/dialog/plugin.js
+++ b/plugins/dialog/plugin.js
@@ -176,7 +176,7 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 			'</div>';
 
 	function buildDialog( editor ) {
-		var element = CKEDITOR.dom.element.createFromHtml( CKEDITOR.addTemplate( 'dialog', templateSource ).output( {
+		var element = CKEDITOR.dom.element.createFromHtml( CKEDITOR.tools.legacyUnsafeHtml(CKEDITOR.addTemplate( 'dialog', templateSource ).output( {
 			id: CKEDITOR.tools.getNextNumber(),
 			editorId: editor.id,
 			langDir: editor.lang.dir,
@@ -184,7 +184,7 @@ CKEDITOR.DIALOG_STATE_BUSY = 2;
 			editorDialogClass: 'cke_editor_' + editor.name.replace( /\./g, '\\.' ) + '_dialog',
 			closeTitle: editor.lang.common.close,
 			hidpi: CKEDITOR.env.hidpi ? 'cke_hidpi' : ''
-		} ) );
+		} )) );
 
 		// TODO: Change this to getById(), so it'll support custom templates.
 		var body = element.getChild( [ 0, 0, 0, 0, 0 ] ),

--- a/plugins/elementspath/plugin.js
+++ b/plugins/elementspath/plugin.js
@@ -222,7 +222,7 @@
 			}
 
 			var space = getSpaceElement();
-			space.setHtml( CKEDITOR.tools.htmlLegacyConverted(html.join( '' ) + emptyHtmld) );
+			space.setHtml( CKEDITOR.tools.legacyUnsafeHtml(html.join( '' ) + emptyHtml) );
 			editor.fire( 'elementsPathUpdate', { space: space } );
 		} );
 

--- a/plugins/elementspath/plugin.js
+++ b/plugins/elementspath/plugin.js
@@ -222,7 +222,7 @@
 			}
 
 			var space = getSpaceElement();
-			space.setHtml( html.join( '' ) + emptyHtml );
+			space.setHtml( CKEDITOR.tools.htmlLegacyConverted(html.join( '' ) + emptyHtmld) );
 			editor.fire( 'elementsPathUpdate', { space: space } );
 		} );
 

--- a/plugins/embedbase/plugin.js
+++ b/plugins/embedbase/plugin.js
@@ -424,7 +424,7 @@
 						request.task.done();
 					}
 
-					this._setContent( request.url, evtData.html );
+					this._setContent( request.url, CKEDITOR.tools.htmlLegacyConverted(evtData.html) );
 					return true;
 				} else {
 					request.errorCallback( evtData.errorMessage );

--- a/plugins/embedbase/plugin.js
+++ b/plugins/embedbase/plugin.js
@@ -424,7 +424,7 @@
 						request.task.done();
 					}
 
-					this._setContent( request.url, CKEDITOR.tools.htmlLegacyConverted(evtData.html) );
+					this._setContent( request.url, CKEDITOR.tools.legacyUnsafeHtml(evtData.html) );
 					return true;
 				} else {
 					request.errorCallback( evtData.errorMessage );

--- a/plugins/floatingspace/plugin.js
+++ b/plugins/floatingspace/plugin.js
@@ -282,7 +282,7 @@
 						'<div id="{topId}" class="cke_top" role="presentation">{content}</div>' +
 					'</div>' +
 				'</div>' ),
-				floatSpace = CKEDITOR.document.getBody().append( CKEDITOR.dom.element.createFromHtml( floatSpaceTpl.output( {
+				floatSpace = CKEDITOR.document.getBody().append( CKEDITOR.dom.element.createFromHtml( CKEDITOR.tools.legacyUnsafeHtml(floatSpaceTpl.output( {
 					content: topHtml,
 					id: editor.id,
 					langDir: editor.lang.dir,
@@ -291,7 +291,7 @@
 					style: 'display:none;z-index:' + ( config.baseFloatZIndex - 1 ),
 					topId: editor.ui.spaceId( 'top' ),
 					voiceLabel: editor.applicationTitle
-				} ) ) ),
+				} ) )) ),
 
 				// Use event buffers to reduce CPU load when tons of events are fired.
 				changeBuffer = CKEDITOR.tools.eventsBuffer( 500, layout ),

--- a/plugins/image2/plugin.js
+++ b/plugins/image2/plugin.js
@@ -582,10 +582,10 @@
 					// There was no caption, but the caption is to be added.
 					if ( newValue ) {
 						// Create new <figure> from widget template.
-						var figure = CKEDITOR.dom.element.createFromHtml( templateBlock.output( {
+						var figure = CKEDITOR.dom.element.createFromHtml( CKEDITOR.tools.legacyUnsafeHtml(templateBlock.output( {
 							captionedClass: captionedClass,
 							captionPlaceholder: editor.lang.image2.captionPlaceholder
-						} ), doc );
+						} )), doc );
 
 						// Replace element with <figure>.
 						replaceSafely( figure, shift.element );

--- a/plugins/imagebase/plugin.js
+++ b/plugins/imagebase/plugin.js
@@ -436,7 +436,7 @@
 				tplParams = CKEDITOR.tools.extend( {}, tplParams );
 				tplParams.src = blobUrl;
 
-				var element = CKEDITOR.dom.element.createFromHtml( widgetDef.template.output( tplParams ) ),
+				var element = CKEDITOR.dom.element.createFromHtml( CKEDITOR.tools.legacyUnsafeHtml(widgetDef.template.output( tplParams )) ),
 					wrapper = editor.widgets.wrapElement( element, widgetDef.name ),
 					temp = new CKEDITOR.dom.documentFragment( wrapper.getDocument() );
 

--- a/plugins/panel/plugin.js
+++ b/plugins/panel/plugin.js
@@ -122,10 +122,10 @@
 								this.onLoad();
 						}, this ) );
 
-						doc.write( frameDocTpl.output( CKEDITOR.tools.extend( {
+						doc.write( CKEDITOR.tools.legacyUnsafeHtml(frameDocTpl.output( CKEDITOR.tools.extend( {
 							css: CKEDITOR.tools.buildStyleHtml( this.css ),
 							onload: 'window.parent.CKEDITOR.tools.callFunction(' + onLoad + ');'
-						}, data ) ) );
+						}, data ) )) );
 
 						var win = doc.getWindow();
 

--- a/plugins/widget/plugin.js
+++ b/plugins/widget/plugin.js
@@ -2035,7 +2035,7 @@
 					// ... or create a brand-new widget from template.
 					var defaults = typeof widgetDef.defaults == 'function' ? widgetDef.defaults() : widgetDef.defaults,
 						templateData = CKEDITOR.tools.object.merge( defaults || {}, commandData && commandData.startupData || {} ),
-						element = CKEDITOR.dom.element.createFromHtml( widgetDef.template.output( templateData ), editor.document ),
+						element = CKEDITOR.dom.element.createFromHtml( CKEDITOR.tools.legacyUnsafeHtml(widgetDef.template.output( templateData )), editor.document ),
 						instance,
 						wrapper = editor.widgets.wrapElement( element, widgetDef.name ),
 						temp = new CKEDITOR.dom.documentFragment( wrapper.getDocument() );


### PR DESCRIPTION
## What is the purpose of this pull request?

First PR to add tooling and legacy convert certain violations specifically coming from setHtml wrapper function to help with making CKEditor [Trusted Types](https://developer.mozilla.org/en-US/docs/Web/API/Trusted_Types_API) compatible.

The tooling would be used as follows:
```javascript
element.innerHtml = CKEDITOR.tools.htmlLegacyConverted(legacyHtml);
```

### template.output
The [template.output](https://sourcegraph.com/github.com/ckeditor/ckeditor4/-/blob/core/template.js?L60-68) function is to be legacy converted as it is possibly unsafe. We legacy convert the usages at each of the sinks rather than converting the output directly because some functions that take template outputs rely on the value being a string rather than a TrustedType.