### PR TITLE
[Trusted Types] Some last stray violations/semantic changes + config change for codemirror

### DIFF
--- a/ckeditor.js
+++ b/ckeditor.js
@@ -27,7 +27,7 @@ else {
 	} else {
 		if (self.trustedTypes && self.trustedTypes.createPolicy) {
 			// The CKEDITOR.getUrl function should be safe since the basePath calculated in ckeditor_base.js is pulled from the script elements on the page or is developer controlled by a window flag.
-			const policy = self.trustedTypes.createPolicy(
+			var policy = self.trustedTypes.createPolicy(
 				'ckeditor#scriptloader',
 				{
 					createHTML: function (html) {

--- a/config.js
+++ b/config.js
@@ -8,69 +8,8 @@ CKEDITOR.editorConfig = function( config ) {
 	// config.language = 'fr';
 	// config.uiColor = '#AADC6E';
 	// %REMOVE_START%
-	config.plugins =
-		'about,' +
-		'a11yhelp,' +
-		'basicstyles,' +
-		'bidi,' +
-		'blockquote,' +
-		'clipboard,' +
-		'colorbutton,' +
-		'colordialog,' +
-		'copyformatting,' +
-		'contextmenu,' +
-		'dialogadvtab,' +
-		'div,' +
-		'elementspath,' +
-		'enterkey,' +
-		'entities,' +
-		'filebrowser,' +
-		'find,' +
-		'floatingspace,' +
-		'font,' +
-		'format,' +
-		'forms,' +
-		'horizontalrule,' +
-		'htmlwriter,' +
-		'image,' +
-		'iframe,' +
-		'indentlist,' +
-		'indentblock,' +
-		'justify,' +
-		'language,' +
-		'link,' +
-		'list,' +
-		'liststyle,' +
-		'magicline,' +
-		'maximize,' +
-		'newpage,' +
-		'pagebreak,' +
-		'pastefromgdocs,' +
-		'pastefromlibreoffice,' +
-		'pastefromword,' +
-		'pastetext,' +
-		'editorplaceholder,' +
-		'preview,' +
-		'print,' +
-		'removeformat,' +
-		'resize,' +
-		'save,' +
-		'selectall,' +
-		'showblocks,' +
-		'showborders,' +
-		'smiley,' +
-		'sourcearea,' +
-		'specialchar,' +
-		'stylescombo,' +
-		'tab,' +
-		'table,' +
-		'tableselection,' +
-		'tabletools,' +
-		'templates,' +
-		'toolbar,' +
-		'undo,' +
-		'uploadimage,' +
-		'wysiwygarea';
+	config.plugins = 'dialogui,dialog,about,a11yhelp,basicstyles,blockquote,notification,button,toolbar,clipboard,panel,floatpanel,menu,contextmenu,resize,elementspath,enterkey,entities,popup,filetools,filebrowser,floatingspace,listblock,richcombo,format,horizontalrule,htmlwriter,wysiwygarea,image,indent,indentlist,fakeobjects,link,list,magicline,maximize,pastetext,xml,ajax,pastetools,pastefromgdocs,pastefromword,removeformat,showborders,sourcearea,specialchar,stylescombo,tab,table,tabletools,tableselection,undo,lineutils,widgetselection,widget,notificationaggregator,uploadwidget,uploadimage,autogrow,bidi,panelbutton,colorbutton,colordialog,dialogadvtab,div,find,flash,font,forms,iframe,indentblock,justify,menubutton,language,liststyle,newpage,pagebreak,preview,print,save,selectall,sharedspace,templates,codemirror';
+
 	// %REMOVE_END%
 };
 

--- a/core/loader.js
+++ b/core/loader.js
@@ -139,7 +139,7 @@ if ( !CKEDITOR.loader ) {
 				script.type = 'text/javascript';
 				if (self.trustedTypes && self.trustedTypes.createPolicy) {
 					// The CKEDITOR.getUrl function should be safe since the basePath calculated in ckeditor_base.js is pulled from the script elements on the page or is developer controlled by a window flag.
-					const policy = self.trustedTypes.createPolicy(
+					var policy = self.trustedTypes.createPolicy(
 						'loader#loadPending',
 						{
 							createScriptURL: function (url) {
@@ -234,7 +234,7 @@ if ( !CKEDITOR.loader ) {
 					this.loadedScripts.push( scriptName );
 					if (self.trustedTypes && self.trustedTypes.createPolicy) {
 						// The CKEDITOR.getUrl function should be safe since the basePath calculated in ckeditor_base.js is pulled from the script elements on the page or is developer controlled by a window flag.
-						const policy = self.trustedTypes.createPolicy(
+						var policy = self.trustedTypes.createPolicy(
 							'loader#load',
 							{
 								createHTML: function (html) {

--- a/plugins/dialogui/plugin.js
+++ b/plugins/dialogui/plugin.js
@@ -1473,7 +1473,7 @@ CKEDITOR.plugins.add( 'dialogui', {
 
 					var inputId = _.frameId + '_input';
 
-					frameDocument.$.write( [
+					frameDocument.$.write( CKEDITOR.tools.legacyUnsafeHtml( [
 						'<html dir="' + langDir + '" lang="' + langCode + '"><head><title></title></head><body style="margin: 0; overflow: hidden; background: transparent;">',
 							'<form enctype="multipart/form-data" method="POST" dir="' + langDir + '" lang="' + langCode + '" action="',
 								CKEDITOR.tools.htmlEncode( elementDefinition.action ),
@@ -1497,7 +1497,7 @@ CKEDITOR.plugins.add( 'dialogui', {
 							'window.parent.CKEDITOR.tools.callFunction(' + callNumber + ');',
 							'window.onbeforeunload = function() {window.parent.CKEDITOR.tools.callFunction(' + unloadNumber + ')}',
 						'</script>'
-					].join( '' ) );
+					].join( '' ) ));
 
 					frameDocument.$.close();
 

--- a/plugins/lineutils/plugin.js
+++ b/plugins/lineutils/plugin.js
@@ -888,7 +888,7 @@
 		 * @returns {CKEDITOR.dom.element} A brand-new line.
 		 */
 		addLine: function() {
-			var line = CKEDITOR.dom.element.createFromHtml( CKEDITOR.legacyUnsafeHtml(this.lineTpl) );
+			var line = CKEDITOR.dom.element.createFromHtml( CKEDITOR.tools.legacyUnsafeHtml(this.lineTpl) );
 
 			line.appendTo( this.container );
 

--- a/plugins/lineutils/plugin.js
+++ b/plugins/lineutils/plugin.js
@@ -888,7 +888,7 @@
 		 * @returns {CKEDITOR.dom.element} A brand-new line.
 		 */
 		addLine: function() {
-			var line = CKEDITOR.dom.element.createFromHtml( this.lineTpl );
+			var line = CKEDITOR.dom.element.createFromHtml( CKEDITOR.legacyUnsafeHtml(this.lineTpl) );
 
 			line.appendTo( this.container );
 

--- a/plugins/popup/plugin.js
+++ b/plugins/popup/plugin.js
@@ -58,7 +58,7 @@ CKEDITOR.tools.extend( CKEDITOR.editor.prototype, {
 			if (self.trustedTypes && self.trustedTypes.createPolicy) {
 				// This is a legacy conversion. This url is passed by plugins/filebrowser which should be only accessible 
 				// by the developer but the url is modified in too many areas for this to be fully safe.
-				const policy = self.trustedTypes.createPolicy(
+				var policy = self.trustedTypes.createPolicy(
 					'plugin#popup',
 					{
 						createScriptURL: function (url) {

--- a/plugins/sharedspace/plugin.js
+++ b/plugins/sharedspace/plugin.js
@@ -56,7 +56,7 @@
 				}, null, null, 1 );  // Hi-priority
 
 				// Inject the space into the target.
-				space = target.append( CKEDITOR.dom.element.createFromHtml( containerTpl.output( {
+				space = target.append( CKEDITOR.dom.element.createFromHtml( CKEDITOR.tools.legacyUnsafeHtml(containerTpl.output( {
 					id: editor.id,
 					name: editor.name,
 					langDir: editor.lang.dir,
@@ -64,7 +64,7 @@
 					space: spaceName,
 					spaceId: editor.ui.spaceId( spaceName ),
 					content: innerHtml
-				} ) ) );
+				} ) ) ) );
 
 				// Only the first container starts visible. Others get hidden.
 				if ( target.getCustomData( 'cke_hasshared' ) )


### PR DESCRIPTION
Seems one of the template.output legacy conversions got lost in the process of moving it from one PR to another and there might have been something similar that happened to a doc.write violation. I also just added the correct ordering for the config.plugins list. Other than that, the rest is just semantic fixes.